### PR TITLE
fix_client_timeout

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+  - Added timeout to `HTTP::Tiny`
+
 0.003     2024-10-07 10:20:54+00:00 UTC
   - Updated `exchange_token` to support caller payload
 0.002     2024-10-02 22:21:04+00:00 UTC

--- a/lib/WebService/Hydra/Client.pm
+++ b/lib/WebService/Hydra/Client.pm
@@ -17,6 +17,7 @@ use Syntax::Keyword::Try;
 use constant OK_STATUS_CODE          => 200;
 use constant OK_NO_CONTENT_CODE      => 204;
 use constant BAD_REQUEST_STATUS_CODE => 400;
+use constant HTTP_TIMEOUT_SECONDS    => 10;
 
 our $VERSION = '0.004';
 
@@ -76,7 +77,7 @@ Return HTTP object.
 =cut
 
 method http {
-    return $http //= HTTP::Tiny->new();
+    return $http //= HTTP::Tiny->new(timeout => HTTP_TIMEOUT_SECONDS);
 }
 
 =head2 jwks


### PR DESCRIPTION
# Description
Adding timeout to http client to prevent the process form getting stuck when hydra is not reachable.
