### PR TITLE
Reject login request

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,6 @@
 {{$NEXT}}
+
+0.005     2024-12-31 09:00:16+00:00 UTC
   - Added reject_login_request method
 
 0.004     2024-12-03 10:30:12+00:00 UTC

--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+- Added reject_login_request method
+
 0.004     2024-12-03 10:30:12+00:00 UTC
 
   - Added timeout to `HTTP::Tiny`

--- a/Changes
+++ b/Changes
@@ -1,6 +1,5 @@
 {{$NEXT}}
-
-- Added reject_login_request method
+  - Added reject_login_request method
 
 0.004     2024-12-03 10:30:12+00:00 UTC
   - Added timeout to `HTTP::Tiny`

--- a/Changes
+++ b/Changes
@@ -3,11 +3,11 @@
 - Added reject_login_request method
 
 0.004     2024-12-03 10:30:12+00:00 UTC
-
   - Added timeout to `HTTP::Tiny`
 
 0.003     2024-10-07 10:20:54+00:00 UTC
   - Updated `exchange_token` to support caller payload
+
 0.002     2024-10-02 22:21:04+00:00 UTC
   - Bug fix in `validate_token` and `validate_id_token` methods.
 

--- a/lib/WebService/Hydra.pm
+++ b/lib/WebService/Hydra.pm
@@ -1,9 +1,9 @@
 package WebService::Hydra;
-# ABSTRACT: ...
+# ABSTRACT: Interact with the Hydra service API
 
 use strict;
 use warnings;
 
-our $VERSION = '0.004';
+our $VERSION = '0.005';
 
 1;

--- a/lib/WebService/Hydra/Client.pm
+++ b/lib/WebService/Hydra/Client.pm
@@ -250,7 +250,7 @@ Payload to be sent to the Hydra service to reject the login request.
 method reject_login_request ($login_challenge, $reject_payload) {
     my $method = "PUT";
     my $path   = "$admin_endpoint/admin/oauth2/auth/requests/login/reject?challenge=$login_challenge";
-    
+
     my $result = $self->api_call($method, $path, $reject_payload);
     if ($result->{code} != OK_STATUS_CODE) {
         WebService::Hydra::Exception::InvalidLoginRequest->new(

--- a/lib/WebService/Hydra/Client.pm
+++ b/lib/WebService/Hydra/Client.pm
@@ -19,7 +19,7 @@ use constant OK_NO_CONTENT_CODE      => 204;
 use constant BAD_REQUEST_STATUS_CODE => 400;
 use constant HTTP_TIMEOUT_SECONDS    => 10;
 
-our $VERSION = '0.005';
+our $VERSION = '0.006';
 
 field $http;
 field $jwks;

--- a/lib/WebService/Hydra/Client.pm
+++ b/lib/WebService/Hydra/Client.pm
@@ -227,6 +227,41 @@ method accept_login_request ($login_challenge, $accept_payload) {
     return $result->{data};
 }
 
+=head2 reject_login_request
+
+Rejects the login request and returns the response from hydra.
+
+Arguments:
+
+=over 1
+
+=item C<$login_challenge>
+
+Authentication challenge string that is used to identify the login request.
+
+=item C<$reject_payload>
+
+Payload to be sent to the Hydra service to reject the login request.
+
+=back
+
+=cut
+
+method reject_login_request ($login_challenge, $reject_payload) {
+    my $method = "PUT";
+    my $path   = "$admin_endpoint/admin/oauth2/auth/requests/login/reject?challenge=$login_challenge";
+    
+    my $result = $self->api_call($method, $path, $reject_payload);
+    if ($result->{code} != OK_STATUS_CODE) {
+        WebService::Hydra::Exception::InvalidLoginRequest->new(
+            message  => "Failed to reject login request",
+            category => "client",
+            details  => $result
+        )->throw;
+    }
+    return $result->{data};
+}
+
 =head2 get_logout_request
 
 Get the logout request and return the response from Hydra.

--- a/lib/WebService/Hydra/Client.pm
+++ b/lib/WebService/Hydra/Client.pm
@@ -319,9 +319,9 @@ Exchanges the authorization code with Hydra service for access and ID tokens.
 =cut
 
 method exchange_token ($exchange_payload) {
-    my $method     = "POST";
-    my $path       = "$public_endpoint/oauth2/token";
-    my $payload    = {
+    my $method  = "POST";
+    my $path    = "$public_endpoint/oauth2/token";
+    my $payload = {
         grant_type => 'authorization_code',
         $exchange_payload->%*
     };

--- a/t/unit/hydra_client.t
+++ b/t/unit/hydra_client.t
@@ -568,7 +568,7 @@ subtest 'reject_login_request' => sub {
         code => 200,
         data => {redirect_to => 'http://dummyhydra.com/error'}
     };
-    
+
     my $got = $client->reject_login_request("VALID_CHALLENGE", $reject_payload);
     is $params[1], 'PUT', 'PUT request method';
     is $params[2], 'http://dummyhydra.com/admin/admin/oauth2/auth/requests/login/reject?challenge=VALID_CHALLENGE',
@@ -585,7 +585,7 @@ subtest 'reject_login_request' => sub {
             status_code       => 400
         }
     };
-    
+
     dies_ok { $client->reject_login_request("INVALID_CHALLENGE", $reject_payload) } 
         'Dies if non-200 status code is received from api_call';
     

--- a/t/unit/hydra_client.t
+++ b/t/unit/hydra_client.t
@@ -556,25 +556,24 @@ subtest 'reject_login_request' => sub {
     );
 
     my $reject_payload = {
-        error            => 'access_denied',
-        error_debug     => 'User authentication failed',
+        error             => 'access_denied',
+        error_debug       => 'User authentication failed',
         error_description => 'Invalid credentials provided',
-        error_hint      => 'Check your username and password',
-        status_code     => 401
+        error_hint        => 'Check your username and password',
+        status_code       => 401
     };
 
     # Test for 200 OK status code
     $mock_api_response = {
         code => 200,
-        data => {redirect_to => 'http://dummyhydra.com/error'}
-    };
+        data => {redirect_to => 'http://dummyhydra.com/error'}};
 
     my $got = $client->reject_login_request("VALID_CHALLENGE", $reject_payload);
     is $params[1], 'PUT', 'PUT request method';
     is $params[2], 'http://dummyhydra.com/admin/admin/oauth2/auth/requests/login/reject?challenge=VALID_CHALLENGE',
         'Request URL built with correct parameters';
-    is_deeply $params[3], $reject_payload, 'Request payload is correct';
-    is_deeply $got, $mock_api_response->{data}, 'api_call response correctly parsed';
+    is_deeply $params[3], $reject_payload,            'Request payload is correct';
+    is_deeply $got,       $mock_api_response->{data}, 'api_call response correctly parsed';
 
     # Test for non-200 status codes
     $mock_api_response = {
@@ -583,13 +582,12 @@ subtest 'reject_login_request' => sub {
             error             => "string",
             error_description => "string",
             status_code       => 400
-        }
-    };
+        }};
 
-    dies_ok { $client->reject_login_request("INVALID_CHALLENGE", $reject_payload) } 
-        'Dies if non-200 status code is received from api_call';
-    
-    my $exception = $@;
+    dies_ok { $client->reject_login_request("INVALID_CHALLENGE", $reject_payload) }
+    'Dies if non-200 status code is received from api_call';
+
+    my $exception          = $@;
     my $expected_exception = WebService::Hydra::Exception::InvalidLoginRequest->new(
         message  => 'Failed to reject login request',
         category => 'client',
@@ -604,8 +602,8 @@ subtest 'reject_login_request' => sub {
             die "Request to http://dummyhydra.com/admin/oauth2/auth/requests/login/reject?challenge=VALID_CHALLENGE failed - Network issue";
         });
 
-    dies_ok { $client->reject_login_request("VALID_CHALLENGE", $reject_payload) } 
-        'Dies if http request fails for some reason';
+    dies_ok { $client->reject_login_request("VALID_CHALLENGE", $reject_payload) }
+    'Dies if http request fails for some reason';
 };
 
 subtest 'validate_token' => sub {

--- a/t/unit/hydra_client.t
+++ b/t/unit/hydra_client.t
@@ -539,6 +539,75 @@ subtest 'oidc_config' => sub {
 
 };
 
+subtest 'reject_login_request' => sub {
+    my $mock_hydra = Test::MockModule->new('WebService::Hydra::Client');
+    my $mock_api_response;
+    my @params;
+    $mock_hydra->redefine(
+        'api_call',
+        sub {
+            (@params) = @_;
+            return $mock_api_response;
+        });
+
+    my $client = WebService::Hydra::Client->new(
+        admin_endpoint  => 'http://dummyhydra.com/admin',
+        public_endpoint => 'http://dummyhydra.com'
+    );
+
+    my $reject_payload = {
+        error            => 'access_denied',
+        error_debug     => 'User authentication failed',
+        error_description => 'Invalid credentials provided',
+        error_hint      => 'Check your username and password',
+        status_code     => 401
+    };
+
+    # Test for 200 OK status code
+    $mock_api_response = {
+        code => 200,
+        data => {redirect_to => 'http://dummyhydra.com/error'}
+    };
+    
+    my $got = $client->reject_login_request("VALID_CHALLENGE", $reject_payload);
+    is $params[1], 'PUT', 'PUT request method';
+    is $params[2], 'http://dummyhydra.com/admin/admin/oauth2/auth/requests/login/reject?challenge=VALID_CHALLENGE',
+        'Request URL built with correct parameters';
+    is_deeply $params[3], $reject_payload, 'Request payload is correct';
+    is_deeply $got, $mock_api_response->{data}, 'api_call response correctly parsed';
+
+    # Test for non-200 status codes
+    $mock_api_response = {
+        code => 400,
+        data => {
+            error             => "string",
+            error_description => "string",
+            status_code       => 400
+        }
+    };
+    
+    dies_ok { $client->reject_login_request("INVALID_CHALLENGE", $reject_payload) } 
+        'Dies if non-200 status code is received from api_call';
+    
+    my $exception = $@;
+    my $expected_exception = WebService::Hydra::Exception::InvalidLoginRequest->new(
+        message  => 'Failed to reject login request',
+        category => 'client',
+        details  => $mock_api_response
+    );
+    is_deeply $exception, $expected_exception, 'Return api_call response for Non 200 status code';
+
+    # Test network failure
+    $mock_hydra->redefine(
+        'api_call',
+        sub {
+            die "Request to http://dummyhydra.com/admin/oauth2/auth/requests/login/reject?challenge=VALID_CHALLENGE failed - Network issue";
+        });
+
+    dies_ok { $client->reject_login_request("VALID_CHALLENGE", $reject_payload) } 
+        'Dies if http request fails for some reason';
+};
+
 subtest 'validate_token' => sub {
     my $mock_hydra       = Test::MockModule->new('WebService::Hydra::Client');
     my $mock_token       = 'mock.jwt.token';


### PR DESCRIPTION
# Description

Add support for rejecting a login request with an error payload. this will redirect back to the callback with an error result. 
https://www.ory.sh/docs/hydra/reference/api#tag/oAuth2/operation/rejectOAuth2LoginRequest